### PR TITLE
Fix property sync event

### DIFF
--- a/client/client.lua
+++ b/client/client.lua
@@ -26,9 +26,13 @@ function InitialiseProperties(properties)
         ApartmentsTable[k] = Apartment:new(v)
     end
 
-	if not properties then
-    	properties = lib.callback.await('ps-housing:server:requestProperties')
-	end
+    if not properties then
+        properties = lib.callback.await('ps-housing:server:requestProperties')
+        if not properties then
+            TriggerServerEvent('ps-housing:server:requestProperties')
+            return -- wait for server to send them back
+        end
+    end
 	
     for k, v in pairs(properties) do
         createProperty(v.propertyData)

--- a/server/server.lua
+++ b/server/server.lua
@@ -1,6 +1,6 @@
 DoorResource = GetResourceState('ox_doorlock') == 'started' and 'ox' or GetResourceState('qb-doorlock') == 'started' and 'qb'
-if not DoorResource then 
-    return error('ox_doorlock/qb-doorlock must be started before ps-housing.') 
+if not DoorResource then
+    return error('ox_doorlock/qb-doorlock must be started before ps-housing.')
 end
 
 QBCore = exports['qb-core']:GetCoreObject()
@@ -63,6 +63,14 @@ lib.callback.register("ps-housing:server:requestProperties", function()
     end
 
     return PropertiesTable
+end)
+
+RegisterNetEvent('ps-housing:server:requestProperties', function()
+    local src = source
+    while not dbloaded do
+        Wait(100)
+    end
+    TriggerClientEvent('ps-housing:client:initialiseProperties', src, PropertiesTable)
 end)
 
 function RegisterProperty(propertyData, preventEnter, source)


### PR DESCRIPTION
## Summary
- revert doorlock wait logic
- add network event that sends properties to clients
- call the event if the callback returns nothing

## Testing
- `npx --yes playwright test` *(fails: `EHOSTUNREACH`)*